### PR TITLE
added support for ordered hashtables

### DIFF
--- a/Modules/MarkdownPS/New-MDTable.Tests.ps1
+++ b/Modules/MarkdownPS/New-MDTable.Tests.ps1
@@ -5,7 +5,7 @@ $VerbosePreference="SilentlyContinue"
 $newLine=[System.Environment]::NewLine
 Describe "New-MDTable" {
     It "-Object is null" {
-        {New-MDTable -Object $null} | Should Throw "because it is null."
+        Invoke-Command -ScriptBlock {TRY{New-MDTable -Object $null} CATCH{Return $_.FullyQualifiedErrorId}} | Should Be "ParameterArgumentValidationErrorNullNotAllowed,New-MDTable"
     }
 }
 Describe "New-MDTable without columns" {

--- a/Modules/MarkdownPS/New-MDTable.Tests.ps1
+++ b/Modules/MarkdownPS/New-MDTable.Tests.ps1
@@ -45,6 +45,38 @@ Describe "New-MDTable with columns" {
     }
 }
 
+Describe "New-MDTable with ordered hashtable and without columns" {
+    $object=[PSCustomObject]@{
+        Name = "This should be the first value"
+        ZProperty = "This should be in the middle"
+        AnotherProperty = "This should be the last value"
+    }
+    It "-NoNewLine not specified" {
+        $expected=4
+        ((New-MDTable -Object $object) -split [System.Environment]::NewLine).Length | Should Be $expected
+        (($object | New-MDTable) -split [System.Environment]::NewLine).Length | Should Be $expected
+        ((@($object, $object) | New-MDTable) -split [System.Environment]::NewLine).Length | Should Be ($expected+1)
+    }
+    It "-NoNewLine not specified" {
+        $expected=3
+        ((New-MDTable -Object $object -NoNewLine) -split [System.Environment]::NewLine).Length | Should Be $expected
+        (($object | New-MDTable -NoNewLine) -split [System.Environment]::NewLine).Length | Should Be $expected
+        ((@($object, $object) | New-MDTable -NoNewLine) -split [System.Environment]::NewLine).Length | Should Be ($expected+1)
+    }
+    It "Header should be in correct order" {
+        $HeaderRegex = "^\|\s([\w\d]+)\s*\|\s([\w\d]+)\s*\|\s([\w\d]+)\s*\|$"
+        $expectedHeader = ($object.PsObject.Members | Where-Object {$_.MemberType -eq "NoteProperty"})[0..2].Name
+        (((New-MDTable -Object $object) -split [System.Environment]::NewLine)[0]) -match $HeaderRegex
+        $Matches[1..3] | Should Be $expectedHeader
+
+        ((($object | New-MDTable) -split [System.Environment]::NewLine)[0]) -match $HeaderRegex
+        $Matches[1..3] | Should Be $expectedHeader
+
+        (((@($object, $object) | New-MDTable) -split [System.Environment]::NewLine)[0]) -match $HeaderRegex
+        $Matches[1..3] | Should Be $expectedHeader
+    }
+}
+
 Describe "New-MDTable with ordered columns" {
     $object=Get-Command New-MDTable 
     $columns=[ordered]@{

--- a/Modules/MarkdownPS/New-MDTable.ps1
+++ b/Modules/MarkdownPS/New-MDTable.ps1
@@ -91,7 +91,7 @@ function New-MDTable {
         }
         if(-not $Columns)
         {
-            $Columns=@{}
+            $Columns=[ordered]@{}
             ForEach($item in $Object) 
             {
                 $item.PSObject.Properties | %{


### PR DESCRIPTION
**This fix allows the cmdlet `New-MDTable` to support ordered hashtables.**  
I've found out, that the cmdlet New-MDTable does not support ordered hashtables or `[pscustomobject]`.
If i declare a `[pscustomobject][ordered]` with a defined order of properties, this order is ignored by the cmdlet and the column order of the table is randomly:
```powershell
C:\> Import-Module MarkdownPS
C:\> $Object = [pscustomobject][ordered]@{
  Name = "ThisIsMyNameProperty"
  AnotherProperty = "This is another property"
  LastProperty = "This property should be the last column in the Markdown table"
}
C:\> New-MDTable -Object $Object
| AnotherProperty                                               | Name                                                          | LastProperty                                                  |
| ------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------- | 
| This is another property                                      | ThisIsMyNameProperty                                          | This property should be the last column in the Markdown table |
```
The expected result of the cmdlet should be:
```powershell
| Name                                                          | AnotherProperty                                               | LastProperty                                                  |
| ------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------- |
| ThisIsMyNameProperty                                          | This is another property                                      | This property should be the last column in the Markdown table |
```