### PR TITLE
Update New-MDTable.ps1

### DIFF
--- a/Src/Modules/MarkdownPS/Public/New-MDTable.ps1
+++ b/Src/Modules/MarkdownPS/Public/New-MDTable.ps1
@@ -166,7 +166,7 @@ function New-MDTable {
             switch($Columns[$key]) 
             {
                 "left" {
-                    $separator += ' '+ $dashes +' '
+                    $separator += ':'+ $dashes +' '
                 }
                 "right" {
                     $separator += ' '+ $dashes +':'


### PR DESCRIPTION
Fix missing colon in Left separator.

Existing code does not add the left aligned colon to left align text, e.g. in the command below, the left aligned column is missing the colon character

```PowerShell
Get-Command New-MDTable | New-MDTable -Columns ([ordered]@{Name="left";CommandType="center";Version="right"})
| Name        | CommandType | Version |
| ----------- |:-----------:| -------:|
| New-MDTable | Function    | 1.9     |
```