### PR TITLE
Updated MDQuote and MDAlert to address issue #43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 **v1.10** *In progress*
-- Fixed issue with GH-33 where the `New-MDQuote` would output extra `> ` between quote lines
 - GH-28 Added new command `New-MDAlert` for GFM Alerts. Thanks to @belibug
 - GH-42 Fixed a bug with the left alignment of columns with `New-MDTable`. Thanks to @aaronparker
-- Fixed issue with GH-43 where `New-MDQuote` and `New-MDAlert` did not output new line spacing for multiline input
 
 **v1.9** *20200227*
 - Based on GH-20 the default output of `New-MDTable` has a cell length alignment per column. New parameter `-Shrink` is added to reduce the overall size and each cell is not padded. Thanks to @al-cheb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fixed issue with GH-33 where the `New-MDQuote` would output extra `> ` between quote lines
 - GH-28 Added new command `New-MDAlert` for GFM Alerts. Thanks to @belibug
 - GH-42 Fixed a bug with the left alignment of columns with `New-MDTable`. Thanks to @aaronparker
+- Fixed issue with GH-43 where `New-MDQuote` and `New-MDAlert` did not output new line spacing for multiline input
 
 **v1.9** *20200227*
 - Based on GH-20 the default output of `New-MDTable` has a cell length alignment per column. New parameter `-Shrink` is added to reduce the overall size and each cell is not padded. Thanks to @al-cheb

--- a/Showcase/Showcase.md
+++ b/Showcase/Showcase.md
@@ -49,6 +49,7 @@ In the words of Abraham Lincoln:
 Multi line quote
 
 > Line 1
+>
 > Line 2
 
 # Github Flavoured Markdown Alerts
@@ -61,6 +62,7 @@ Multi line Alert with 'Tip' Style
 
 > [!TIP]
 > Helpful advice 
+>
 > for doing things better or more easily.
 
 # Links
@@ -100,7 +102,6 @@ Without aligned columns
 
 | Name                 | CommandType | Version |
 | -------------------- | ----------- | ------- |
-| New-MDAlert          | Function    | 0.0     |
 | New-MDCharacterStyle | Function    | 0.0     |
 | New-MDCode           | Function    | 0.0     |
 | New-MDHeader         | Function    | 0.0     |
@@ -115,7 +116,6 @@ With aligned columns
 
 | Name                 | CommandType | Version |
 |:-------------------- |:-----------:| -------:|
-| New-MDAlert          | Function    | 0.0     |
 | New-MDCharacterStyle | Function    | 0.0     |
 | New-MDCode           | Function    | 0.0     |
 | New-MDHeader         | Function    | 0.0     |

--- a/Showcase/Showcase.md
+++ b/Showcase/Showcase.md
@@ -102,6 +102,7 @@ Without aligned columns
 
 | Name                 | CommandType | Version |
 | -------------------- | ----------- | ------- |
+| New-MDAlert          | Function    | 0.0     |
 | New-MDCharacterStyle | Function    | 0.0     |
 | New-MDCode           | Function    | 0.0     |
 | New-MDHeader         | Function    | 0.0     |
@@ -116,6 +117,7 @@ With aligned columns
 
 | Name                 | CommandType | Version |
 |:-------------------- |:-----------:| -------:|
+| New-MDAlert          | Function    | 0.0     |
 | New-MDCharacterStyle | Function    | 0.0     |
 | New-MDCode           | Function    | 0.0     |
 | New-MDHeader         | Function    | 0.0     |

--- a/Src/Modules/MarkdownPS/Public/New-MDAlert.Tests.ps1
+++ b/Src/Modules/MarkdownPS/Public/New-MDAlert.Tests.ps1
@@ -24,7 +24,7 @@ Describe -Tag @('MarkdownPS', 'Cmdlet', 'Public', 'New-MDAlert') 'New-MDAlert' {
         @('Line 1') | New-MDAlert | Should -Be $expected
     }
     It '-Lines count is 2 & -Style not specified' {
-        $expected = '> [!NOTE]' + $newLine + '> Line 1' + $newLine + '> Line 2' + $newLine + $newLine
+        $expected = '> [!NOTE]' + $newLine + '> Line 1' + $newLine + '>' + $newLine + '> Line 2' + $newLine + $newLine
         # New-MDAlert -Lines @('Line 1', 'Line 2') | Should -Be $expected
         @('Line 1', 'Line 2') | New-MDAlert | Should -Be $expected
     }
@@ -36,7 +36,7 @@ Describe -Tag @('MarkdownPS', 'Cmdlet', 'Public', 'New-MDAlert') 'New-MDAlert' {
         @('Line 1') | New-MDAlert -Style Tip | Should -Be $expected
     }
     It '-Lines count is 2 & -Level provided' {
-        $expected = '> [!TIP]' + $newLine + '> Line 1' + $newLine + '> Line 2' + $newLine + $newLine
+        $expected = '> [!TIP]' + $newLine + '> Line 1' + $newLine + '>' + $newLine + '> Line 2' + $newLine + $newLine
         New-MDAlert -Lines @('Line 1', 'Line 2') -Style Tip | Should -Be $expected
         @('Line 1', 'Line 2') | New-MDAlert -Style Tip | Should -Be $expected
     }

--- a/Src/Modules/MarkdownPS/Public/New-MDAlert.Tests.ps1
+++ b/Src/Modules/MarkdownPS/Public/New-MDAlert.Tests.ps1
@@ -25,7 +25,7 @@ Describe -Tag @('MarkdownPS', 'Cmdlet', 'Public', 'New-MDAlert') 'New-MDAlert' {
     }
     It '-Lines count is 2 & -Style not specified' {
         $expected = '> [!NOTE]' + $newLine + '> Line 1' + $newLine + '>' + $newLine + '> Line 2' + $newLine + $newLine
-        # New-MDAlert -Lines @('Line 1', 'Line 2') | Should -Be $expected
+        New-MDAlert -Lines @('Line 1', 'Line 2') | Should -Be $expected
         @('Line 1', 'Line 2') | New-MDAlert | Should -Be $expected
     }
     It '-Lines count is 1 & -Style provided' {

--- a/Src/Modules/MarkdownPS/Public/New-MDAlert.ps1
+++ b/Src/Modules/MarkdownPS/Public/New-MDAlert.ps1
@@ -80,18 +80,16 @@ function New-MDAlert {
         $newLine = [System.Environment]::NewLine
         $admonition = '> [!{0}]' -f $Style.ToUpper()
         $output += $admonition + $newLine
-        $processCallCounter = 0
+        $allLines = @()
     }
     
     Process {
-        $processCallCounter++
-        if ($processCallCounter -gt 1) { 
-            $output += '>' + $newLine
-        }
-        $output += New-MDQuote -Lines $Lines -Level 1 -NoNewLine
+        # Buffer all lines, because the Process block will process each line separately and provided to the New-MDQuote which will not add the separators
+        $allLines += $Lines
     }
-    
+        
     End {
+        $output += New-MDQuote -Lines $allLines -Level 1 -NoNewLine
         if (-not $NoNewLine) {
             $output += $newLine
         }

--- a/Src/Modules/MarkdownPS/Public/New-MDAlert.ps1
+++ b/Src/Modules/MarkdownPS/Public/New-MDAlert.ps1
@@ -80,9 +80,14 @@ function New-MDAlert {
         $newLine = [System.Environment]::NewLine
         $admonition = '> [!{0}]' -f $Style.ToUpper()
         $output += $admonition + $newLine
+        $processCallCounter = 0
     }
     
     Process {
+        $processCallCounter++
+        if ($processCallCounter -gt 1) { 
+            $output += '>' + $newLine
+        }
         $output += New-MDQuote -Lines $Lines -Level 1 -NoNewLine
     }
     

--- a/Src/Modules/MarkdownPS/Public/New-MDQuote.Tests.ps1
+++ b/Src/Modules/MarkdownPS/Public/New-MDQuote.Tests.ps1
@@ -25,7 +25,7 @@ Describe -Tag @("MarkdownPS","Cmdlet","Public","New-MDQuote") "New-MDQuote" {
         @("Line 1") | New-MDQuote | Should -Be $expected
     }
     It "-Lines count is 2 & -Level not specified" {
-        $expected="> Line 1"+$newLine+"> Line 2"+$newLine+$newLine
+        $expected="> Line 1"+$newLine+">"+$newLine+"> Line 2"+$newLine+$newLine
         New-MDQuote -Lines @("Line 1","Line 2") | Should -Be $expected
         @("Line 1","Line 2") | New-MDQuote | Should -Be $expected
     }
@@ -52,17 +52,17 @@ Describe -Tag @("MarkdownPS","Cmdlet","Public","New-MDQuote") "New-MDQuote" {
         @("Line 1") | New-MDQuote  -Level $level | Should -Be $expected
     }
     It "-Lines count is 2 & -Level provided" {
-        $expected="> Line 1"+$newLine+"> Line 2"+$newLine+$newLine
+        $expected="> Line 1"+$newLine+">"+$newLine+"> Line 2"+$newLine+$newLine
         $level=1
         New-MDQuote -Lines @("Line 1","Line 2") -Level $level | Should -Be $expected
         @("Line 1","Line 2") | New-MDQuote  -Level $level | Should -Be $expected
 
-        $expected=">> Line 1"+$newLine+">> Line 2"+$newLine+$newLine
+        $expected=">> Line 1"+$newLine+">>"+$newLine+">> Line 2"+$newLine+$newLine
         $level=2
         New-MDQuote -Lines @("Line 1","Line 2") -Level $level | Should -Be $expected
         @("Line 1","Line 2") | New-MDQuote  -Level $level | Should -Be $expected
 
-        $expected=">>> Line 1"+$newLine+">>> Line 2"+$newLine+$newLine
+        $expected=">>> Line 1"+$newLine+">>>"+$newLine+">>> Line 2"+$newLine+$newLine
         $level=3
         New-MDQuote -Lines @("Line 1","Line 2") -Level $level | Should -Be $expected
         @("Line 1","Line 2") | New-MDQuote  -Level $level | Should -Be $expected
@@ -78,7 +78,7 @@ Describe -Tag @("MarkdownPS","Cmdlet","Public") "New-MDQuote -NoNewLine specifie
         @("Line 1") | New-MDQuote -NoNewLine | Should -Be $expected
     }
     It "-Lines count is 2 & -Level not specified" {
-        $expected="> Line 1"+$newLine+"> Line 2"+$newLine
+        $expected="> Line 1"+$newLine+">"+$newLine+"> Line 2"+$newLine
         New-MDQuote -Lines @("Line 1","Line 2") -NoNewLine | Should -Be $expected
         @("Line 1","Line 2") | New-MDQuote -NoNewLine | Should -Be $expected
     }
@@ -105,17 +105,17 @@ Describe -Tag @("MarkdownPS","Cmdlet","Public") "New-MDQuote -NoNewLine specifie
         @("Line 1") | New-MDQuote  -Level $level -NoNewLine | Should -Be $expected
     }
     It "-Lines count is 2 & -Level provided" {
-        $expected="> Line 1"+$newLine+"> Line 2"+$newLine
+        $expected="> Line 1"+$newLine+">"+$newLine+"> Line 2"+$newLine
         $level=1
         New-MDQuote -Lines @("Line 1","Line 2") -Level $level -NoNewLine | Should -Be $expected
         @("Line 1","Line 2") | New-MDQuote  -Level $level -NoNewLine | Should -Be $expected
 
-        $expected=">> Line 1"+$newLine+">> Line 2"+$newLine
+        $expected=">> Line 1"+$newLine+">>"+$newLine+">> Line 2"+$newLine
         $level=2
         New-MDQuote -Lines @("Line 1","Line 2") -Level $level -NoNewLine | Should -Be $expected
         @("Line 1","Line 2") | New-MDQuote  -Level $level -NoNewLine | Should -Be $expected
 
-        $expected=">>> Line 1"+$newLine+">>> Line 2"+$newLine
+        $expected=">>> Line 1"+$newLine+">>>"+$newLine+">>> Line 2"+$newLine
         $level=3
         New-MDQuote -Lines @("Line 1","Line 2") -Level $level -NoNewLine | Should -Be $expected
         @("Line 1","Line 2") | New-MDQuote  -Level $level -NoNewLine | Should -Be $expected

--- a/Src/Modules/MarkdownPS/Public/New-MDQuote.ps1
+++ b/Src/Modules/MarkdownPS/Public/New-MDQuote.ps1
@@ -81,6 +81,10 @@ function New-MDQuote {
 
     Process {
         $Lines|ForEach-Object {
+            if($output -ne "")
+            {
+                $output+="$prefix"+[System.Environment]::NewLine
+            }
             $output+="$prefix "+$_+[System.Environment]::NewLine
         }
     }


### PR DESCRIPTION
This should fix the line break issue with markdown.

New multiline quote

> This is line 1
>
> This is Line 2

and new multiline alert

> [!TIP]
> This is line 1
>
> This is line 2